### PR TITLE
chore: fix Camel 4.9.0 tests

### DIFF
--- a/packages/ui/src/components/Form/dataFormat/DataFormatEditor.test.tsx
+++ b/packages/ui/src/components/Form/dataFormat/DataFormatEditor.test.tsx
@@ -160,7 +160,7 @@ describe('DataFormatEditor', () => {
       fireEvent.change(inputElement, { target: { value: 'json' } });
     });
     dropdownItems = screen.getAllByTestId(/dataformat-dropdownitem-.*/);
-    expect(dropdownItems).toHaveLength(3);
+    expect(dropdownItems).toHaveLength(4);
   });
 
   it('should clear filter and close the dropdown with close button', async () => {
@@ -174,7 +174,7 @@ describe('DataFormatEditor', () => {
       fireEvent.change(inputElement, { target: { value: 'json' } });
     });
     let dropdownItems = screen.getAllByTestId(/dataformat-dropdownitem-.*/);
-    expect(dropdownItems).toHaveLength(3);
+    expect(dropdownItems).toHaveLength(4);
     const clearButton = screen.getByLabelText('Clear input value');
     await act(async () => {
       fireEvent.click(clearButton);

--- a/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
+++ b/packages/ui/src/models/visualization/flows/support/__snapshots__/camel-component-schema.service.test.ts.snap
@@ -303,13 +303,13 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "type": "string",
       },
       "variableReceive": {
-        "description": "To use a variable to store the received message body (only body, not headers). This is handy for easy access to the received message body via variables. Important: When using receive variable then the received body is stored only in this variable and not on the current org.apache.camel.Message .",
+        "description": "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message.",
         "group": "common",
         "title": "Variable Receive",
         "type": "string",
       },
       "variableSend": {
-        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current Message , however the headers from the Message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
+        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
         "group": "common",
         "title": "Variable Send",
         "type": "string",
@@ -656,13 +656,13 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "type": "string",
       },
       "variableReceive": {
-        "description": "To use a variable to store the received message body (only body, not headers). This is handy for easy access to the received message body via variables. Important: When using receive variable then the received body is stored only in this variable and not on the current org.apache.camel.Message .",
+        "description": "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message.",
         "group": "common",
         "title": "Variable Receive",
         "type": "string",
       },
       "variableSend": {
-        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current Message , however the headers from the Message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
+        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
         "group": "common",
         "title": "Variable Send",
         "type": "string",
@@ -858,6 +858,14 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
             "description": "To let the scheduled polling consumer backoff if there has been a number of subsequent idles/errors in a row. The multiplier is then the number of polls that will be skipped before the next actual attempt is happening again. When this option is in use then backoffIdleThreshold and/or backoffErrorThreshold must also be configured.",
             "group": "scheduler",
             "title": "Backoff Multiplier",
+            "type": "integer",
+          },
+          "browseLimit": {
+            "default": 100,
+            "deprecated": false,
+            "description": "Maximum number of messages to keep in memory available for browsing. Use 0 for unlimited.",
+            "group": "advanced",
+            "title": "Browse Limit",
             "type": "integer",
           },
           "bufferSize": {
@@ -1449,13 +1457,13 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
         "type": "string",
       },
       "variableReceive": {
-        "description": "To use a variable to store the received message body (only body, not headers). This is handy for easy access to the received message body via variables. Important: When using receive variable then the received body is stored only in this variable and not on the current org.apache.camel.Message .",
+        "description": "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message.",
         "group": "common",
         "title": "Variable Receive",
         "type": "string",
       },
       "variableSend": {
-        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current Message , however the headers from the Message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
+        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
         "group": "common",
         "title": "Variable Send",
         "type": "string",
@@ -1560,6 +1568,14 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should build the a
             "group": "consumer (advanced)",
             "title": "Bridge Error Handler",
             "type": "boolean",
+          },
+          "browseLimit": {
+            "default": 100,
+            "deprecated": false,
+            "description": "Maximum number of messages to keep in memory available for browsing. Use 0 for unlimited.",
+            "group": "advanced",
+            "title": "Browse Limit",
+            "type": "integer",
           },
           "bufferSize": {
             "default": 131072,
@@ -2243,13 +2259,13 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should not build a
         "type": "string",
       },
       "variableReceive": {
-        "description": "To use a variable to store the received message body (only body, not headers). This is handy for easy access to the received message body via variables. Important: When using receive variable then the received body is stored only in this variable and not on the current org.apache.camel.Message .",
+        "description": "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message.",
         "group": "common",
         "title": "Variable Receive",
         "type": "string",
       },
       "variableSend": {
-        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current Message , however the headers from the Message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
+        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
         "group": "common",
         "title": "Variable Send",
         "type": "string",
@@ -2436,13 +2452,13 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
         "type": "string",
       },
       "variableReceive": {
-        "description": "To use a variable to store the received message body (only body, not headers). This is handy for easy access to the received message body via variables. Important: When using receive variable then the received body is stored only in this variable and not on the current org.apache.camel.Message .",
+        "description": "To use a variable to store the received message body (only body, not headers). This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using receive variable then the received body is stored only in this variable and not on the current message.",
         "group": "common",
         "title": "Variable Receive",
         "type": "string",
       },
       "variableSend": {
-        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current Message , however the headers from the Message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
+        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
         "group": "common",
         "title": "Variable Send",
         "type": "string",
@@ -2587,7 +2603,7 @@ exports[`CamelComponentSchemaService getVisualComponentSchema should transform a
         "type": "string",
       },
       "variableSend": {
-        "description": "To use a variable to store the received message body (only body, not headers). This is handy for easy access to the received message body via variables. Important: When using receive variable then the received body is stored only in this variable and not on the current org.apache.camel.Message .",
+        "description": "To use a variable as the source for the message body to send. This makes it handy to use variables for user data and to easily control what data to use for sending and receiving. Important: When using send variable then the message body is taken from this variable instead of the current message, however the headers from the message will still be used as well. In other words, the variable is used instead of the message body, but everything else is as usual.",
         "group": "common",
         "title": "Variable Send",
         "type": "string",


### PR DESCRIPTION
### Context
The broken tests are due to changes in the description and the newly added `smooks` data format.